### PR TITLE
Fix typo and old link to Ericsson repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     <section>
       <div class="container bg-shade">
         <h1 class="section-heading">Untangling the network of pipelines</h1>
-        <p class="section-paragraph">Modern software production systems are more than just a build server. It is a shifting mix of functions and technologies, frmo issue trackers and test frameworks to environment managers and repositories. At the same time, software supply chains become increasingly complex, crossing organizational and geographical borders many times before resulting in the final software product. It is a world of interconnected and interdependent software pipelines.</p>
+        <p class="section-paragraph">Modern software production systems are more than just a build server. It is a shifting mix of functions and technologies, from issue trackers and test frameworks to environment managers and repositories. At the same time, software supply chains become increasingly complex, crossing organizational and geographical borders many times before resulting in the final software product. It is a world of interconnected and interdependent software pipelines.</p>
         <p class="section-paragraph">The Eiffel community applies the same architectural principles to this network of pipelines as to any other software design problem. The first part of this is the Eiffel protocol, enabling technology agnostic event-based communication among the actors of the system. The second part is the implementation of services and plugins for sending, storing, analyzing and acting upon those event communications.</p>
         <p class="section-paragraph">The Eiffel protocol and its implementaions lets you know at a glance what is up in your software production system and your supply chain, while providing rich extension points where others can hook into your pipeline with perfect upstream and downstream traceability.
       </div>
@@ -107,7 +107,7 @@
           <a href="https://github.com/Ericsson/eiffel-remrem"><img src="images/eiffel-remrem-logo.png" class="section-paragraph-image" /></a>
           <p class="section-paragraph right-of-image">
             Remrem acts as a REST based mailbox towards an Eiffel message bus. It provides an abstraction that allows its clients to send messages without first integrating with a particular messaging technology, and takes care of most of the heavy lifting involved in authoring and publishing event messages.<br/>
-            Repository: <a href="https://github.com/Ericsson/eiffel-remrem">eiffel-remrem</a><br>
+            Repository: <a href="https://github.com/eiffel-community/eiffel-remrem">eiffel-remrem</a><br>
             Role in <a href="https://eiffel-community.github.io/eiffel-sepia">Sepia</a>: <a href="https://eiffel-community.github.io/eiffel-sepia/event-publishing.html">Event Publishing</a><br/>
             Status: In progress.<br/>
           </p>


### PR DESCRIPTION
REMReM link still pointing to Ericsson repository, so updated with the eiffel-community link.