### PR TITLE
First draft of the agenda for 2021.1 summit

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -71,6 +71,10 @@ svg {
   font-size: 24px;
 }
 
+td p {
+padding: 15px;
+}
+
 @media only screen and (max-width: 1024px) {
   .splash-text-large {
     font-size: 48px;

--- a/summit.html
+++ b/summit.html
@@ -36,11 +36,246 @@
                         </li>
 					</ul>
 				</p>
-        <h1 class="section-heading">Agenda</h1>
-        <p class="section-paragraph">
-					To be added
-        </p>
-        </div>
+        <h1>Agenda</h1>
+        <h2>Day 1 (Wednesday 22nd of September)</h2>
+        <table class="striped ">
+          <thead>
+          <tr>
+            <th>Topic</th>
+            <th>Level</th>
+            <th>Start time</th>
+          </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <details>
+                  <summary>What is Eiffel and why?</summary>
+                  <p>An introduction to Eiffel</p>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>09:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Getting started</summary>
+                  <p>A practical guide on how to get started with Eiffel</p>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>09:30</td>
+            </tr>
+
+            <tr><td>Pause</td><td></td><td>10:30</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>The Eiffel landscape</summary>
+                  <p>An overview of all the different components in the Eiffel community</p>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>11:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Changes in the Paris and Lyon editions of the protocol</summary>
+                  <p>Walthrough of what is new in the Paris and Lyon edition</p>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>11:30</td>
+            </tr>
+
+            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Technical Committee updates</summary>
+                  <p>What has happend in the Techical committee since last time</p>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Maintainer role</summary>
+                  <p>What is the maintainer role, what are its tasks and responsibilities</p>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:30</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>New routing key standard</summary>
+                  <p>
+                    Explanation of the new standard for routing keys described in the Sepia
+                    protocol
+                  </p>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>14:00</td>
+            </tr>
+
+            <tr><td>Pause</td><td></td><td>14:30</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Open issues in the protocol repos</summary>
+                  <p>The audience picks an issue to discuss</p>
+                </details>
+              </td>
+              <td><span class="tag bd-error">Advanced</span></td>
+              <td>15:00</td>
+            </tr>
+
+          </tbody>
+        </table>
+
+        <h2>Day 2 (Thursday 23nd of September)</h2>
+        <table class="striped ">
+          <thead>
+          <tr>
+            <th>Topic</th>
+            <th>Level</th>
+            <th>Start time</th>
+          </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <details>
+                  <summary>Eiffel vs CDF SIG Events protocol on Cloudevents</summary>
+                  <p>What is CDF and how does SIG events protocol suggestion relate to Eiffel</p>
+                </details>
+              </td>
+              <td><span class="tag bd-error">Advanced</span></td>
+              <td>09:00</td>
+            </tr>
+
+              <td>
+                <details>
+                  <summary>eiffel-broadcaster Jenkins plugin</summary>
+                  <p>What is the eiffel-broadcaster Jenkins plugin and how do I use it?</p>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>09:30</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Event SDKs</summary>
+                  <p>What SDK do we have in Eiffel?</p>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>10:00</td>
+            </tr>
+
+            <tr><td>Pause</td><td></td><td>10:30</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>ER Access</summary>
+                  <p>What is an ER and what alternatives are there?</p>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>11:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion: Event type categorization</summary>
+                  <p>Discussion on how to categorize our events</p>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>11:30</td>
+            </tr>
+
+            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion: Source change events</summary>
+                  <p>More info to come...</p>
+                </details>
+              </td>
+              <td><span class="tag bd-error">Advanced</span></td>
+              <td>13:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion: Using Eiffel to implement event-triggered pipelines</summary>
+                  <p>How do I create a flow of pipelines that are triggered by Eiffel events</p>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>14:00</td>
+            </tr>
+            <tr><td>Pause</td><td></td><td>14:30</td></tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion: Extracting common structs</summary>
+                  <p>How should we handle common structures like meta and data.gitIdentifier</p>
+                </details>
+              </td>
+              <td><span class="tag bd-error">Advanced</span></td>
+              <td>15:00</td>
+            </tr>
+
+          </tbody>
+        </table>
+
+      </div>
     </section>
     <div data-include="includes/footer.html"></div>
   </body>


### PR DESCRIPTION

### Applicable Issues
Add an agenda to the 2021.1 summit

### Description of the Change
Add the agenda in HTML format preview can be found on https://m-linner-ericsson.github.io/eiffel-community.github.io/summit.html

### Alternate Designs
A HTML page were chosen to enable collapsable elements and more colors

### Benefits
More people are aware of the summit agenda

### Possible Drawbacks
None that I can think of

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Mattias Linnér mattias.linner@ericsson.com
