### PR TITLE
Archive old summit.html and prepare for 2022.1 summit

### DIFF
--- a/archive/summit-2021-1.html
+++ b/archive/summit-2021-1.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Eiffel Online Summit</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="./images/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="./images/favicon/favicon-16x16.png">
+    <link rel="manifest" href="./manifest.json">
+    <link rel="mask-icon" href="./images/favicon/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel='stylesheet' href='./css/index.css'>
+    <meta name="theme-color" content="#ffffff">
+    <meta charset="UTF-8">
+    <script src="./js/csi.min.js"></script>
+  </head>
+  <body class="container">
+    <div data-include="./includes/header.html"></div>
+    <section>
+      <div>
+        <p class="splash-text-large">Eiffel Virtual Summit 2021.1</p>
+        <p class="splash-text-small">
+          Welcome everyone to the Eiffel Virtual Summit 2021.1!
+        </p>
+      </div>
+    </section>
+    <section>
+      <div>
+        <h1 class="section-heading">The practicals</h1>
+        <p class="section-paragraph">
+					<ul>
+						<li>Where: <a target="_blank" href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NGM1NDM4OGYtYzNmZi00OGY2LTlmODEtZmMyMmY0MDRkMWYy%40thread.v2/0?context=%7b%22Tid%22%3a%2292e84ceb-fbfd-47ab-be52-080c6b87953f%22%2c%22Oid%22%3a%2249725723-aa8c-4dcf-b9d0-b974e8a25702%22%7d">Microsoft Teams Meeting</a></li>
+						<li>When : 22nd-23rd of September, 9:00 - 16:00 CEST</li>
+                        <li>
+                          How: Click <a target="_blank" href="https://video.meet.ericsson.net/webapp/?conference=1254642830&ivr=teams&d=video.meet.ericsson.net&ip=193.180.251.91&test=testcall&w">here</a>
+                          to join from your browser or app<br/>
+                          To join from Non-Ericsson video device: Dial teams@video.meet.ericsson.net, enter the VTC Conference ID 1254642830  followed by #
+                        </li>
+					</ul>
+				</p>
+        <h1>Agenda</h1>
+        <h2>Day 1 (Wednesday 22nd of September)</h2>
+        <table class="striped ">
+          <thead>
+          <tr>
+            <th>Topic</th>
+            <th>Level</th>
+            <th>Start time</th>
+          </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <details>
+                  <summary>What is Eiffel and why?</summary>
+                  <div>
+                    An introduction to Eiffel
+                    <p>
+                      <b>Speaker: </b> Kristofer Hallén
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>09:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Getting started</summary>
+                  <div>
+                    A practical guide on how to get started with Eiffel
+                    <p>
+                      <b>Speaker: </b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>09:30</td>
+            </tr>
+
+            <tr><td>Break</td><td></td><td>10:30</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>The Eiffel landscape</summary>
+                  <div>
+                    An overview of all the different components in the Eiffel community
+                    <p>
+                      <b>Speaker: </b> Mattias Linnér
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>11:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Changes in the Paris and Lyon editions of the protocol</summary>
+                  <div>
+                    Walkthrough of what is new in the Paris and Lyon edition
+                    <p>
+                      <b>Speaker: </b> Emil Bäckmark
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>11:30</td>
+            </tr>
+
+            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Technical Committee updates</summary>
+                  <div>
+                    What has happend in the Techical committee since last time
+                    <p>
+                      <b>Speaker: </b> Emil Bäckmark
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Maintainer role</summary>
+                  <div>
+                    What is the maintainer role, what are its tasks and responsibilities
+                    <p>
+                      <b>Speaker: </b> Emil Bäckmark
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:30</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>New routing key standard</summary>
+                  <div>
+                    Explanation of the new standard for routing keys described in the Sepia
+                    protocol
+                    <p>
+                      <b>Speaker: </b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>14:00</td>
+            </tr>
+
+            <tr><td>Break</td><td></td><td>14:30</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion: Open issues in the protocol repos</summary>
+                  <div>
+                    The audience picks an issue to discuss
+                    <p>
+                      <b>Moderator: </b> TBD
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-error">Advanced</span></td>
+              <td>15:00</td>
+            </tr>
+
+          </tbody>
+        </table>
+
+        <h2>Day 2 (Thursday 23nd of September)</h2>
+        <table class="striped ">
+          <thead>
+          <tr>
+            <th>Topic</th>
+            <th>Level</th>
+            <th>Start time</th>
+          </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <details>
+                  <summary>Eiffel vs CDF SIG Events protocol on Cloudevents</summary>
+                  <div>
+                    What is CDF and how does SIG events protocol suggestion relate to Eiffel
+                    <p>
+                      <b>Speaker: </b> Mattias Linnér
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-error">Advanced</span></td>
+              <td>09:00</td>
+            </tr>
+
+              <td>
+                <details>
+                  <summary>eiffel-broadcaster Jenkins plugin</summary>
+                  <div>
+                    What is the eiffel-broadcaster Jenkins plugin and how do I use it?
+                    <p>
+                      <b>Speaker: </b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>09:30</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Event SDKs</summary>
+                  <div>
+                    What SDK do we have in Eiffel?
+                    <p>
+                      <b>Speaker: </b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>10:00</td>
+            </tr>
+
+            <tr><td>Break</td><td></td><td>10:30</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>ER Access</summary>
+                  <div>
+                    What is an ER and what alternatives are there?
+                    <p>
+                      <b>Speaker: </b> Tobias Persson
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>11:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion: Event type categorization</summary>
+                  <div>
+                    Discussion on how to categorize our events
+                    <p>
+                      <b>Moderator: </b> TBD
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>11:30</td>
+            </tr>
+
+            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion: Source change events</summary>
+                  <div>
+                    More info to come...
+                    <p>
+                      <b>Moderator: </b> TBD
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-error">Advanced</span></td>
+              <td>13:00</td>
+            </tr>
+
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion: Using Eiffel to implement event-triggered pipelines</summary>
+                  <div>
+                    How do I create a flow of pipelines that are triggered by Eiffel events
+                    <p>
+                      <b>Moderator: </b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>14:00</td>
+            </tr>
+            <tr><td>Break</td><td></td><td>14:30</td></tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion: Extracting common structs</summary>
+                  <div>
+                    How should we handle common structures like meta and data.gitIdentifier
+                    <p>
+                      <b>Moderator: </b> TBD
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-error">Advanced</span></td>
+              <td>15:00</td>
+            </tr>
+
+          </tbody>
+        </table>
+
+      </div>
+    </section>
+    <div data-include="includes/footer.html"></div>
+  </body>
+</html>

--- a/summit.html
+++ b/summit.html
@@ -32,7 +32,9 @@
           If you're interested in presenting something
           yourself please reach out to
           <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>
-          no later than September&nbsp;16, 2022.
+          no later than September&nbsp;16, 2022. You can e.g. host a
+          group discussion, a five-minute lightning talk, or a longer
+          traditional talk (30–60&nbsp;minutes).
         </p>
       </div>
     </section>
@@ -42,9 +44,10 @@
         <p class="section-paragraph">
           <ul>
             <li>
-              Where: Nasdaq
-              Stockholm, <a href="https://goo.gl/maps/KpoBwrNw1FPsqcJH8">Tullvaktsvägen
-              15, 105 78 Stockholm, Sweden</a>
+              Where: Nasdaq Stockholm,
+              <a href="https://goo.gl/maps/KpoBwrNw1FPsqcJH8">
+                Tullvaktsvägen&nbsp;15, 105 78 Stockholm, Sweden
+              </a>
             </li>
             <li>
               When: October&nbsp;11, 10:00&nbsp;CEST, to

--- a/summit.html
+++ b/summit.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Eiffel Online Summit</title>
+    <title>Eiffel Summit</title>
     <link rel="apple-touch-icon" sizes="180x180" href="./images/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="./images/favicon/favicon-16x16.png">
@@ -16,502 +16,54 @@
     <div data-include="./includes/header.html"></div>
     <section>
       <div>
-        <p class="splash-text-large">Eiffel Virtual Summit 2021.1</p>
-        <p class="splash-text-small">
-          Welcome everyone to the Eiffel Virtual Summit 2021.1!
+        <p class="splash-text-large">Eiffel Summit 2022.1</p>
+        <p>
+          This in-person two-day conference for people interested in
+          the Eiffel protocol and its ecosystem will have a mix of
+          presentations and discussions. Newcomers as well as
+          experienced practitioners are all welcome.
+        </p>
+        <p>
+          Attendance is free of charge but to ease the planning
+          of the event we ask that you
+          <a href="https://forms.gle/facVZm6Xg2Uu5uCE9">register</a>
+          no later than September&nbsp;30, 2022.
+        <p>
+          If you're interested in presenting something
+          yourself please reach out to
+          <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>
+          no later than September&nbsp;16, 2022.
         </p>
       </div>
     </section>
     <section>
       <div>
-        <h1 class="section-heading">The practicals</h1>
+        <h1 class="section-heading">The practicalities</h1>
         <p class="section-paragraph">
-    <ul>
-      <li>Where: <a target="_blank" href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NGM1NDM4OGYtYzNmZi00OGY2LTlmODEtZmMyMmY0MDRkMWYy%40thread.v2/0?context=%7b%22Tid%22%3a%2292e84ceb-fbfd-47ab-be52-080c6b87953f%22%2c%22Oid%22%3a%2249725723-aa8c-4dcf-b9d0-b974e8a25702%22%7d">Microsoft Teams Meeting</a></li>
-      <li>When : 22nd–23rd of September, 9:00–16:00 CEST</li>
+          <ul>
             <li>
-              How: Click <a target="_blank" href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NGM1NDM4OGYtYzNmZi00OGY2LTlmODEtZmMyMmY0MDRkMWYy%40thread.v2/0?context=%7b%22Tid%22%3a%2292e84ceb-fbfd-47ab-be52-080c6b87953f%22%2c%22Oid%22%3a%2249725723-aa8c-4dcf-b9d0-b974e8a25702%22%7d">here</a>
-              to join from your browser or app<br/>
-              To join from Non-Ericsson video device: Dial teams@video.meet.ericsson.net, enter the VTC Conference ID 1254642830  followed by #
+              Where: Nasdaq
+              Stockholm, <a href="https://goo.gl/maps/KpoBwrNw1FPsqcJH8">Tullvaktsvägen
+              15, 105 78 Stockholm, Sweden</a>
+            </li>
+            <li>
+              When: October&nbsp;11, 10:00&nbsp;CEST, to
+              October&nbsp;12, 15:00&nbsp;CEST
             </li>
             <li>
               Who: To get in touch with the organizers send an email to
               <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>.
             </li>
             <li>
-              Communication: For questions, comments, or suggestions regarding the Summit, please join us on <a href="https://eiffel-workspace.slack.com/archives/C02EKUS4M24">slack</a>.
+              Communication: For questions, comments, or suggestions regarding the Summit, please join us on <a href="https://eiffel-workspace.slack.com/archives/C02EKUS4M24">Slack</a>.
             </li>
-    </ul>
-  </p>
+          </ul>
+        </p>
         <h1>Agenda</h1>
-        <h2>Day 1 (Wednesday 22nd of September)</h2>
-        <table class="striped ">
-          <thead>
-          <tr>
-            <th>Topic</th>
-            <th>Level</th>
-            <th>Start time</th>
-          </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <details>
-                  <summary>What is Eiffel and why?</summary>
-                  <div>
-                    An introduction to Eiffel
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Eiffel%20introduction.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/DQX1Qu4dsQE">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Kristofer Hallén
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>09:00</td>
-            </tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>Getting started</summary>
-                  <div>
-                    A practical guide on how to get started with Eiffel
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Eiffel%20getting%20started.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/I8ZoDR5R2wE">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Magnus Bäck
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>09:30</td>
-            </tr>
-
-            <tr><td>Break</td><td></td><td>10:30</td></tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>The Eiffel landscape</summary>
-                  <div>
-                    An overview of all the different components in the Eiffel community
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/The%20Eiffel%20Landscape.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/3Od5-Avg19Q">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Mattias Linnér
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>11:00</td>
-            </tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>Changes in the Paris and Lyon editions of the protocol</summary>
-                  <div>
-                    Since the last summit one new Eiffel edition has
-                    been published
-                    (<a href="https://github.com/eiffel-community/eiffel/releases/tag/edition-paris">Paris</a>)
-                    and another one is on its way out the door
-                    (<a href="https://github.com/eiffel-community/eiffel/milestone/6">Lyon</a>).
-                    This session walks through which changes have been made.
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Changes%20in%20the%20Protocol%20for%20Paris%20and%20Lyon.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/niHvYkf8iaE">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Emil Bäckmark
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>11:30</td>
-            </tr>
-
-            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>Technical Committee updates</summary>
-                  <div>
-                    What has happend in the
-                    <a href="https://github.com/eiffel-community/community/blob/master/GOVERNANCE.md#technical-committee">Technical committee</a>
-                    since last time?
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Technical%20Committee%20Updates.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/TV_Uecyfxmk">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Emil Bäckmark
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>13:00</td>
-            </tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>Maintainer role</summary>
-                  <div>
-                    What is the maintainer role, what are its tasks and responsibilities
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Maintainer%20Role.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/pgkdpy__JPQ">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Emil Bäckmark
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>13:30</td>
-            </tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>New routing key standard</summary>
-                  <div>
-                    Sepia has recently been updated to standardize
-                    what RabbitMQ routing keys (topics) should be used
-                    when publishing events. This'll enable consumers
-                    to set up narrower subscriptions and not have to
-                    throw many of the received messages. See
-                    <a href="https://github.com/eiffel-community/eiffel-sepia/pull/9">github.com/eiffel-community/eiffel-sepia#9</a>.
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/New%20routing%20key%20standard.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/dz5rm13Gw-Y">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Magnus Bäck
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>14:00</td>
-            </tr>
-
-            <tr><td>Break</td><td></td><td>14:30</td></tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>What's cooking in the community?</summary>
-                  <div>
-                    Many of us have Eiffel-related tools or
-                    integrations in the works. This hour is dedicated
-                    to 5–10 minute talks for showcasing ideas and
-                    things that aren't ready for a full demo or
-                    session but deserve to be shared for spreading
-                    awareness and to collect early feedback.
-                    <p>
-                      We'll schedule these talks ad hoc but to make
-                      things easier we encourage you to contact
-                      <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>
-                      ahead of time and let us know about your talk.
-                    </p>
-                      <ul>
-                        <li>
-                          Fatih Degirmenci: Eiffel GitHub actions
-                          (<a href="https://youtu.be/x1P8Cydv_qA">video</a>)
-                        </li>
-                        <li>
-                          Niklas Aronsson: Eiffel visualizations at Axis
-                          (<a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Eiffel%20visualizations%20at%20Axis.pdf">slides</a>,
-                          <a href="https://youtu.be/O1M9OhHqeCo">video</a>)
-                        </li>
-                        <li>
-                          Magnus Bäck: Exposing logs from ancillary activities
-                          (<a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Exposing%20logs%20from%20ancillary%20activities.pdf">slides</a>,
-                          <a href="https://youtu.be/kkVDOPLhFQM">video</a>)
-                        </li>
-                      </ul>
-                    <p>
-                      <b>Moderator: </b> Emil Bäckmark
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>15:00</td>
-            </tr>
-
-          </tbody>
-        </table>
-
-        <h2>Day 2 (Thursday 23nd of September)</h2>
-        <table class="striped ">
-          <thead>
-          <tr>
-            <th>Topic</th>
-            <th>Level</th>
-            <th>Start time</th>
-          </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <details>
-                  <summary>Eiffel vs CDF SIG Events protocol on Cloudevents</summary>
-                  <div>
-                    What is the <a href="https://cd.foundation/">CD Foundation</a>
-                    (CDF) and how does the protocol under way by its
-                    <a href="https://github.com/cdfoundation/sig-events">SIG events</a>
-                    relate to Eiffel?
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Eiffel%20vs%20CDF%20SIG%20Events%20protocol%20on%20Cloudevents.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/mUZ4vBl3Mzw">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Mattias Linnér
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-error">Advanced</span></td>
-              <td>09:00</td>
-            </tr>
-
-              <td>
-                <details>
-                  <summary>eiffel-broadcaster Jenkins plugin</summary>
-                  <div>
-                    A walkthrough of the features of the
-                    <a href="https://plugins.jenkins.io/eiffel-broadcaster/">eiffel-broadcaster</a>
-                    Jenkins plugin.
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/The%20eiffel-broadcaster%20Jenkins%20plugin.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/fRCq9VosRJA">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Magnus Bäck
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>09:30</td>
-            </tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>Event SDKs</summary>
-                  <div>
-                    Open source libraries, or SDKs, for working with
-                    Eiffel events is missing for most languages. We'll
-                    talk about the available SDKs, how they differ,
-                    and discuss how we want these SDKs to work.
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Event%20SDKs.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/2Q_mcgVLoQE">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Magnus Bäck
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>10:00</td>
-            </tr>
-
-            <tr><td>Break</td><td></td><td>10:30</td></tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>Accessing an event repository</summary>
-                  <div>
-                    Most Eiffel deployments have a centralized event
-                    repository for accessing past events. What options
-                    are there and how do they differ?
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/eiffel-er.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/fzpgju-8k54">Video</a>
-                    </p>
-                    <p>
-                      <b>Speaker: </b> Tobias Persson
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>11:00</td>
-            </tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>Discussion: Event type categorization</summary>
-                  <div>
-                    Event types in Eiffel can be categorized in many
-                    different ways. Sepia makes an attempt, as does
-                    REMReM. Is it relevant to have a single such
-                    categorization, and if so, what would it look like?
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Event%20type%20categorization.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/AVE-zh6aFv8">Video</a>
-                    </p>
-                    <p>
-                      <b>Moderator: </b> Mattias Linnér
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>11:30</td>
-            </tr>
-
-            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>Discussion: Source change events</summary>
-                  <div>
-                    The two Eiffel events for modelling source code changes,
-                    <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md">SCC</a>
-                    and
-                    <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md">SCS</a>,
-                    create some challenges when attempting to use them
-                    to model a Git DAG. Let's talk about the
-                    improvement proposal made in
-                    <a href="https://github.com/eiffel-community/eiffel/issues/261">github.com/eiffel-community/eiffel#261</a>.
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Source%20change%20events.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/ytmUU5cW6KI">Video</a>
-                    </p>
-                    <p>
-                      <b>Moderator: </b> Sven Selberg
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-error">Advanced</span></td>
-              <td>13:00</td>
-            </tr>
-
-            <tr>
-              <td>
-                <details>
-                  <summary>Discussion: Using Eiffel to implement event-triggered pipelines</summary>
-                  <div>
-                    While Eiffel could be used just for traceability
-                    of existing pipelines it's also well-suited for
-                    actual triggering of pipeline tasks. What what are
-                    the challenges when doing this? How do you deal
-                    with error when there's no single entity that
-                    determines the pipeline graph and is responsible
-                    for its execution?
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Using%20Eiffel%20to%20implement%20event-triggered%20pipelines.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/xP7aawtyvyY">Video</a>
-                    </p>
-                    <p>
-                      <b>Moderator: </b> Magnus Bäck
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>14:00</td>
-            </tr>
-            <tr><td>Break</td><td></td><td>14:30</td></tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Discussion: Extracting common structures</summary>
-                  <div>
-                    Today, all Eiffel events have their own entirely
-                    independent schemas. And yet, surely everyone
-                    assumes the <tt>meta</tt>
-                    key's contents to be the same across
-                    all events. There are other keys whose values
-                    effectively have the same schema across more than
-                    one event type. Is this the best we can do or
-                    should we strive to change this and extract
-                    common pieces into external structures that we can
-                    reference in schema files?
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/Extracting%20common%20structures.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/Rvjh8NoeVYM">Video</a>
-                    </p>
-                    <p>
-                      <b>Moderator: </b> Sven Selberg
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-error">Advanced</span></td>
-              <td>15:00</td>
-            </tr>
-
-          </tbody>
-        </table>
-
+        <p>
+          We're still in the early stages of setting up the agenda so
+          please check back later.
+        </p>
       </div>
     </section>
     <div data-include="includes/footer.html"></div>


### PR DESCRIPTION
### Applicable Issues
N/A; we can't write issues for all summit page updates

### Description of the Change
Copy the existing summit.html into the archive directory and rework the one at the old location so it covers the October 2022 summit. So far there's not too much information but we have to start somehow. See it in action at https://magnusbaeck.github.io/eiffel-community.github.io/summit.html.

### Alternate Designs
None.

### Benefits
A single place to post summit-related information.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
