### PR TITLE
Add preliminary summit agenda

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -64,9 +64,301 @@
         </p>
         <h1>Agenda</h1>
         <p>
-          We're still in the early stages of setting up the agenda so
-          please check back later.
+          The agenda below is a draft but it's the best draft we've got.
+          If you're only able to come one of the two days and would like to
+          rearrange the sessions to better fit your needs, reach out and we'll
+          see what we can do.
         </p>
+        <h2>Day 1 (Tuesday, October 11)</h2>
+        <table class="striped ">
+          <thead>
+            <tr>
+              <th>Topic</th>
+              <th>Level</th>
+              <th>Start time</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <details>
+                  <summary>Welcome and introductions</summary>
+                  <div>
+                    <p>
+                      There will no doubt be some new faces so let's
+                      introduce ourselves before we start. Our hosts
+                      might also have practical matters to talk about.
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>10:00</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Community news</summary>
+                  <div>
+                    <ul>
+                      <li>New TC introduction</li>
+                      <li>Decide agenda</li>
+                      <li>New or significantly updated projects</li>
+                    </ul>
+                    <p>
+                      <b>Speaker:</b> ?
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>10:15</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Eiffel at Nasdaq</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> Claes Richard
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>10:45</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Protocol news</summary>
+                  <div>
+                    <ul>
+                      <li>
+                        The new PRECURSOR link type
+                        (<a href="https://github.com/eiffel-community/eiffel/issues/227">issue&nbsp;227</a>)
+                      </li>
+                      <li>
+                        New file format for schemas and documentation
+                        (<a href="https://github.com/eiffel-community/eiffel/issues/282">issue&nbsp;282</a>)
+                      </li>
+                      <li>
+                        Checksums for artifact files
+                        (<a href="https://github.com/eiffel-community/eiffel/issues/290">issue&nbsp;290</a>)
+                      </li>
+                    </ul>
+                    <p>
+                      <b>Speaker:</b> Various
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>11:15</td>
+            </tr>
+            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Ask me anything</summary>
+                  <div>
+                    <p>
+                      An opportunity for anyone to ask any question about Eiffel
+                      and we'll all help out answering. Possible topics include:
+                    </p>
+                    <ul>
+                      <li>How should we actually use events in a particular scenario?</li>
+                      <li>What Eiffel components exists and how do they interact?</li>
+                      <li>How can Eiffel be deployed in production?</li>
+                    </ul>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:00</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Deployment events</summary>
+                  <div>
+                    <p>
+                      Continue the discussion of how deployments should be
+                      modeled with Eiffel
+                      (see <a href="https://github.com/eiffel-community/eiffel/issues/239">issue&nbsp;239</a>).
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>15:00</td>
+            </tr>
+          </tbody>
+        </table>
+        <h2>Day 2 (Wednesday, October 12)</h2>
+        <table class="striped ">
+          <thead>
+            <tr>
+              <th>Topic</th>
+              <th>Level</th>
+              <th>Start time</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <details>
+                  <summary>CDEvents</summary>
+                  <div>
+                    <p>
+                    </p>
+                    <p>
+                      <b>Speaker:</b> Emil Bäckmark &amp; Mattias Linnér
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>09:00</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Java library for Eiffel REMReM</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> ?
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>09:45</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Event categorization</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> Mattias Linnér
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>10:15</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Updates on Eiffel visualizations</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> ?
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>11:00</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Discussion of the maintainer role</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> ?
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>11:30</td>
+            </tr>
+            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>State of ETOS</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> Tobias Persson &amp; Fredrik Fristedt
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:00</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Eiffel 5 years from now</summary>
+                  <div>
+                    <p>
+                      Do we have a vision for where Eiffel should be in 2027?
+                    </p>
+                    <p>
+                      <b>Speaker:</b> ?
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:30</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>
+                    Using Eiffel to peek into OpenEmbedded’s hierarchical
+                    source code structure
+                  </summary>
+                  <div>
+                    <p>
+                      It's not entirely obvious how to model a hiearchical
+                      source code structure like that one used with
+                      OpenEmbedded, where the system as a whole is defined
+                      by multiple source code repositories containing
+                      configuration files that, in turn, reference the
+                      source code of the actual code. This talk will show
+                      how Axis Communications does this.
+                    </p>
+                  </div>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>14:15</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </section>
     <div data-include="includes/footer.html"></div>


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
Add a preliminary agenda for the Oct 2022 summit. We're a week out from the sign-up deadline so let's make it easier for people to decide whether to join. See it live at https://magnusbaeck.github.io/eiffel-community.github.io/summit.html.

If you have any session abstracts or other contributions please let me know during the review, but let's not dwell upon this too much. I'd like to get this out the door without too much delay.

### Alternate Designs
None.

### Benefits
Easier access to the agenda.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
