### PR TITLE
Summit: Change to past tense and add slide links

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -19,22 +19,9 @@
         <p class="splash-text-large">Eiffel Summit 2022.1</p>
         <p>
           This in-person two-day conference for people interested in
-          the Eiffel protocol and its ecosystem will have a mix of
+          the Eiffel protocol and its ecosystem had a mix of
           presentations and discussions. Newcomers as well as
-          experienced practitioners are all welcome.
-        </p>
-        <p>
-          Attendance is free of charge but to ease the planning
-          of the event we ask that you
-          <a href="https://forms.gle/facVZm6Xg2Uu5uCE9">register</a>
-          no later than September&nbsp;30, 2022.
-        <p>
-          If you're interested in presenting something
-          yourself please reach out to
-          <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>
-          no later than September&nbsp;16, 2022. You can e.g. host a
-          group discussion, a five-minute lightning talk, or a longer
-          traditional talk (30–60&nbsp;minutes).
+          experienced practitioners were all welcome.
         </p>
       </div>
     </section>
@@ -63,12 +50,6 @@
           </ul>
         </p>
         <h1>Agenda</h1>
-        <p>
-          The agenda below is a draft but it's the best draft we've got.
-          If you're only able to come one of the two days and would like to
-          rearrange the sessions to better fit your needs, reach out and we'll
-          see what we can do.
-        </p>
         <h2>Day 1 (Tuesday, October 11)</h2>
         <table class="striped ">
           <thead>
@@ -90,7 +71,7 @@
                       might also have practical matters to talk about.
                     </p>
                     <p>
-                      <b>Speaker:</b> Claes Richard &amp; Emil Bäckmark
+                      <b>Speaker:</b> Claes Richárd &amp; Emil Bäckmark
                     </p>
                   </div>
                 </details>
@@ -141,7 +122,10 @@
                   <summary>Eiffel at Nasdaq</summary>
                   <div>
                     <p>
-                      <b>Speaker:</b> Claes Richard
+                      <b>Speaker:</b> Claes Richárd
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_at_nasdaq.pdf">Slides</a>
                     </p>
                   </div>
                 </details>
@@ -238,6 +222,9 @@
                     <p>
                       <b>Speaker:</b> Emil Bäckmark &amp; Mattias Linnér
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_vs_cdevents.pdf">Slides</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -293,6 +280,8 @@
                       <li>
                         New file format for schemas and documentation
                         (<a href="https://github.com/eiffel-community/eiffel/issues/282">issue&nbsp;282</a>)
+                        |
+                        <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/new_format_for_eiffel_schema_definitions.pdf">Slides</a>
                       </li>
                       <li>
                         meta.schemaUri
@@ -318,6 +307,9 @@
                   <div>
                     <p>
                       <b>Speaker:</b> Tobias Persson &amp; Fredrik Fristedt
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/state_of_etos_2022.pdf">Slides</a>
                     </p>
                   </div>
                 </details>
@@ -348,6 +340,9 @@
                     <p>
                       <b>Speaker:</b> Magnus Bäck
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_with_openembedded_source_structure.pdf">Slides</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -364,7 +359,7 @@
                   <summary>Environment events and more</summary>
                   <div>
                     <p>
-                      <b>Speaker:All</b> TBD
+                      <b>Moderator:</b> Magnus Bäck
                     </p>
                   </div>
                 </details>
@@ -396,7 +391,7 @@
                   <summary>Wrap-up</summary>
                   <div>
                     <p>
-                      <b>Moderator:</b> Claes Richard &amp; Emil Bäckmark
+                      <b>Moderator:</b> Claes Richárd &amp; Emil Bäckmark
                     </p>
                   </div>
                 </details>


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
Add presentation slides and remove text that doesn't make sense to keep around now that the event is over. Preview at https://magnusbaeck.github.io/eiffel-community.github.io/summit.html.

### Alternate Designs
None.

### Benefits
Make slides more widely available. Stop talking about a past event using future tense.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
