### PR TITLE
Summit: Add YouTube links

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -126,6 +126,8 @@
                     </p>
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_at_nasdaq.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/OjfVzYiQQo4">Video</a>
                     </p>
                   </div>
                 </details>
@@ -224,6 +226,8 @@
                     </p>
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_vs_cdevents.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/EWODpCgxSTs">Video</a>
                     </p>
                   </div>
                 </details>
@@ -294,6 +298,9 @@
                     <p>
                       <b>Speaker:</b> Emil Bäckmark &amp; Magnus Bäck
                     </p>
+                    <p>
+                      <a href="https://youtu.be/akg9GYAdrXs">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -310,6 +317,8 @@
                     </p>
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/state_of_etos_2022.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/ZCCsYELOztk">Video</a>
                     </p>
                   </div>
                 </details>
@@ -342,6 +351,8 @@
                     </p>
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_with_openembedded_source_structure.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/RgBUGgU6F4M">Video</a>
                     </p>
                   </div>
                 </details>


### PR DESCRIPTION
### Applicable Issues
N/A; trivial

### Description of the Change
Add YouTube links to summit.html to make the videos from the 2022 summit more accessible. See preview at https://magnusbaeck.github.io/eiffel-community.github.io/summit.html.

### Alternate Designs
None.

### Benefits
Easier to find the presentation recordings.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
