### PR TITLE
Update Slack link on community page

### DIFF
--- a/community.html
+++ b/community.html
@@ -19,7 +19,7 @@
         <p class="centered-text">Join our <a href="https://groups.google.com/forum/#!forum/eiffel-community">Google Group</a> to join the conversation on the Eiffel protocol and its implementations.</p>
         <p class="centered-text"> You can find a <a href="https://github.com/eiffel-community/community/blob/master/PROJECTS.md">list of maintainers</a> in
           the Eiffel community repository.</p>
-        <p class="centered-text">You are welcome to join our <a href="https://join.slack.com/t/eiffel-workspace/shared_invite/enQtOTI3MzEzMzY4Mzg0LTA3NDVmNjgzZjk1YTFjNzk5OWE4MjExYzE1ODU1NzA1YzY5MzhlZmYxZmIwMzhiM2ExOWM4ZGJlYzdkN2M5OTE">Slack Workspace</a>.</p>
+        <p class="centered-text">You are welcome to join our <a href="https://join.slack.com/t/eiffel-workspace/shared_invite/zt-1nuw8446s-Dlv5xsItI7QaWj56s4mLdg">Slack Workspace</a>.</p>
       </div>
     </section>
 


### PR DESCRIPTION
The old Slack link had expired

### Applicable Issues
Solves #42 

### Description of the Change
Updates the Slack invite link to a working one

### Alternate Designs
None

### Benefits
Working link

### Possible Drawbacks
None

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emil Bäckmark emil.backmark@ericsson.com
