### PR TITLE
Add "Other summits" final section to all summit pages

### DIFF
--- a/community.html
+++ b/community.html
@@ -19,7 +19,7 @@
         <p class="centered-text">Join our <a href="https://groups.google.com/forum/#!forum/eiffel-community">Google Group</a> to join the conversation on the Eiffel protocol and its implementations.</p>
         <p class="centered-text"> You can find a <a href="https://github.com/eiffel-community/community/blob/master/PROJECTS.md">list of maintainers</a> in
           the Eiffel community repository.</p>
-        <p class="centered-text">You are welcome to join our <a href="https://join.slack.com/t/eiffel-workspace/shared_invite/enQtOTI3MzEzMzY4Mzg0LTA3NDVmNjgzZjk1YTFjNzk5OWE4MjExYzE1ODU1NzA1YzY5MzhlZmYxZmIwMzhiM2ExOWM4ZGJlYzdkN2M5OTE">Slack Workspace</a>.</p>
+        <p class="centered-text">You are welcome to join our <a href="https://join.slack.com/t/eiffel-workspace/shared_invite/zt-1nuw8446s-Dlv5xsItI7QaWj56s4mLdg">Slack Workspace</a>.</p>
       </div>
     </section>
 

--- a/summit-2019-2.html
+++ b/summit-2019-2.html
@@ -117,6 +117,7 @@
           <ul>
             <li><a href="summit-2020-1.html">Summit 2020-1</a></li>
             <li><a href="summit-2021-1.html">Summit 2021-1</a></li>
+            <li><a href="summit.html">Summit 2022-1</a></li>
           </ul>
         </p>
       </div>

--- a/summit-2019-2.html
+++ b/summit-2019-2.html
@@ -112,7 +112,7 @@
     </section>
     <section>
       <div>
-        <h1 class="section-heading">Past summits</h1>
+        <h1 class="section-heading">Other summits</h1>
         <p class="section-paragraph">
           <ul>
             <li><a href="summit-2020-1.html">Summit 2020-1</a></li>

--- a/summit-2019-2.html
+++ b/summit-2019-2.html
@@ -110,6 +110,17 @@
         </p>
       </div>
     </section>
+    <section>
+      <div>
+        <h1 class="section-heading">Past summits</h1>
+        <p class="section-paragraph">
+          <ul>
+            <li><a href="summit-2020-1.html">Summit 2020-1</a></li>
+            <li><a href="summit-2021-1.html">Summit 2021-1</a></li>
+          </ul>
+        </p>
+      </div>
+    </section>
     <div data-include="includes/footer.html"></div>
   </body>
 </html>

--- a/summit-2019-2.html
+++ b/summit-2019-2.html
@@ -2,18 +2,18 @@
 <html>
   <head>
     <title>Eiffel</title>
-    <link rel="apple-touch-icon" sizes="180x180" href="../images/favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="../images/favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="images/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="manifest" href="../manifest.json">
     <link rel="mask-icon" href="../images/favicon/safari-pinned-tab.svg" color="#5bbad5">
-    <link rel='stylesheet' href='../css/index.css'>
+    <link rel='stylesheet' href='css/index.css'>
     <meta name="theme-color" content="#ffffff">
       <meta charset="UTF-8">
-    <script src="../js/csi.min.js"></script>
+    <script src="js/csi.min.js"></script>
   </head>
   <body class="container">
-    <div data-include="../includes/header.html"></div>
+    <div data-include="includes/header.html"></div>
     <section>
       <div>
         <p class="splash-text-large">Eiffel Summit 2019.2</p>
@@ -44,7 +44,7 @@
 				<iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d17978.80986515653!2d13.220603!3d55.717648000000004!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x6bb7258b9bbdd4e8!2sAxis%20Communications!5e0!3m2!1sen!2sse!4v1569581021411!5m2!1sen!2sse" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
         </p>
         <h2 class="section-heading">Parking (Summit is located 'HERE')</h2>
-				<img src="../images/axis_map.png" />
+				<img src="images/axis_map.png" />
         <h2 class="section-heading">Hotel tips</h2>
         <p class="section-paragraph">
 					If you are traveling from far away and coming down to us in southern Sweden, we understand that you might want to have some tips of where you can stay during your visit.
@@ -110,6 +110,6 @@
         </p>
       </div>
     </section>
-    <div data-include="../includes/footer.html"></div>
+    <div data-include="includes/footer.html"></div>
   </body>
 </html>

--- a/summit-2020-1.html
+++ b/summit-2020-1.html
@@ -45,6 +45,17 @@
 				</p>
         </div>
     </section>
+    <section>
+      <div>
+        <h1 class="section-heading">Past summits</h1>
+        <p class="section-paragraph">
+          <ul>
+            <li><a href="summit-2019-2.html">Summit 2019-2</a></li>
+            <li><a href="summit-2021-1.html">Summit 2021-1</a></li>
+          </ul>
+        </p>
+      </div>
+    </section>
     <div data-include="includes/footer.html"></div>
   </body>
 </html>

--- a/summit-2020-1.html
+++ b/summit-2020-1.html
@@ -2,18 +2,18 @@
 <html>
   <head>
     <title>Eiffel Online Summit</title>
-    <link rel="apple-touch-icon" sizes="180x180" href="./images/favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="./images/favicon/favicon-16x16.png">
-    <link rel="manifest" href="./manifest.json">
-    <link rel="mask-icon" href="../images/favicon/safari-pinned-tab.svg" color="#5bbad5">
-    <link rel='stylesheet' href='../css/index.css'>
+    <link rel="apple-touch-icon" sizes="180x180" href="images/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
+    <link rel="manifest" href="manifest.json">
+    <link rel="mask-icon" href="images/favicon/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel='stylesheet' href='css/index.css'>
     <meta name="theme-color" content="#ffffff">
 		<meta charset="UTF-8">
-    <script src="../js/csi.min.js"></script>
+    <script src="js/csi.min.js"></script>
   </head>
   <body class="container">
-    <div data-include="../includes/header.html"></div>
+    <div data-include="includes/header.html"></div>
     <section>
       <div>
         <p class="splash-text-large">Eiffel Online Summit 2020.1 hosted by Ericsson</p>
@@ -45,6 +45,6 @@
 				</p>
         </div>
     </section>
-    <div data-include="../includes/footer.html"></div>
+    <div data-include="includes/footer.html"></div>
   </body>
 </html>

--- a/summit-2020-1.html
+++ b/summit-2020-1.html
@@ -52,6 +52,7 @@
           <ul>
             <li><a href="summit-2019-2.html">Summit 2019-2</a></li>
             <li><a href="summit-2021-1.html">Summit 2021-1</a></li>
+            <li><a href="summit.html">Summit 2022-1</a></li>
           </ul>
         </p>
       </div>

--- a/summit-2020-1.html
+++ b/summit-2020-1.html
@@ -47,7 +47,7 @@
     </section>
     <section>
       <div>
-        <h1 class="section-heading">Past summits</h1>
+        <h1 class="section-heading">Other summits</h1>
         <p class="section-paragraph">
           <ul>
             <li><a href="summit-2019-2.html">Summit 2019-2</a></li>

--- a/summit-2021-1.html
+++ b/summit-2021-1.html
@@ -516,7 +516,7 @@
     </section>
     <section>
       <div>
-        <h1 class="section-heading">Past summits</h1>
+        <h1 class="section-heading">Other summits</h1>
         <p class="section-paragraph">
           <ul>
             <li><a href="summit-2019-2.html">Summit 2019-2</a></li>

--- a/summit-2021-1.html
+++ b/summit-2021-1.html
@@ -514,6 +514,17 @@
 
       </div>
     </section>
+    <section>
+      <div>
+        <h1 class="section-heading">Past summits</h1>
+        <p class="section-paragraph">
+          <ul>
+            <li><a href="summit-2019-2.html">Summit 2019-2</a></li>
+            <li><a href="summit-2020-1.html">Summit 2020-1</a></li>
+          </ul>
+        </p>
+      </div>
+    </section>
     <div data-include="includes/footer.html"></div>
   </body>
 </html>

--- a/summit-2021-1.html
+++ b/summit-2021-1.html
@@ -521,6 +521,7 @@
           <ul>
             <li><a href="summit-2019-2.html">Summit 2019-2</a></li>
             <li><a href="summit-2020-1.html">Summit 2020-1</a></li>
+            <li><a href="summit.html">Summit 2022-1</a></li>
           </ul>
         </p>
       </div>

--- a/summit-2021-1.html
+++ b/summit-2021-1.html
@@ -2,18 +2,18 @@
 <html>
   <head>
     <title>Eiffel Online Summit</title>
-    <link rel="apple-touch-icon" sizes="180x180" href="./images/favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="./images/favicon/favicon-16x16.png">
-    <link rel="manifest" href="./manifest.json">
-    <link rel="mask-icon" href="./images/favicon/safari-pinned-tab.svg" color="#5bbad5">
-    <link rel='stylesheet' href='./css/index.css'>
+    <link rel="apple-touch-icon" sizes="180x180" href="nimages/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
+    <link rel="manifest" href="manifest.json">
+    <link rel="mask-icon" href="images/favicon/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel='stylesheet' href='css/index.css'>
     <meta name="theme-color" content="#ffffff">
     <meta charset="UTF-8">
-    <script src="./js/csi.min.js"></script>
+    <script src="js/csi.min.js"></script>
   </head>
   <body class="container">
-    <div data-include="./includes/header.html"></div>
+    <div data-include="includes/header.html"></div>
     <section>
       <div>
         <p class="splash-text-large">Eiffel Virtual Summit 2021.1</p>

--- a/summit.html
+++ b/summit.html
@@ -414,6 +414,18 @@
         </table>
       </div>
     </section>
+    <section>
+      <div>
+        <h1 class="section-heading">Past summits</h1>
+        <p class="section-paragraph">
+          <ul>
+            <li><a href="summit-2019-2.html">Summit 2019-2</a></li>
+            <li><a href="summit-2020-1.html">Summit 2020-1</a></li>
+            <li><a href="summit-2021-1.html">Summit 2021-1</a></li>
+          </ul>
+        </p>
+      </div>
+    </section>
     <div data-include="includes/footer.html"></div>
   </body>
 </html>

--- a/summit.html
+++ b/summit.html
@@ -416,7 +416,7 @@
     </section>
     <section>
       <div>
-        <h1 class="section-heading">Past summits</h1>
+        <h1 class="section-heading">Other summits</h1>
         <p class="section-paragraph">
           <ul>
             <li><a href="summit-2019-2.html">Summit 2019-2</a></li>


### PR DESCRIPTION
### Applicable Issues
#37 

### Description of the Change
The new section at the end of every summit page makes the other summit pages more visible. Without this you have to look into the Git repository and read the files there or use it construct a URL.

Note that this PR is based on #45 so changes from both PRs will show up in the diff. In the diff view you can choose to only include one of the commits. The PR has been deployed to https://magnusbaeck.github.io/eiffel-community.github.io.

### Alternate Designs
None.

### Benefits
Old material can be found.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
