### PR TITLE
summit.html: Update for 2023.1 summit

### DIFF
--- a/summit-2019-2.html
+++ b/summit-2019-2.html
@@ -117,7 +117,8 @@
           <ul>
             <li><a href="summit-2020-1.html">Summit 2020-1</a></li>
             <li><a href="summit-2021-1.html">Summit 2021-1</a></li>
-            <li><a href="summit.html">Summit 2022-1</a></li>
+            <li><a href="summit-2022-1.html">Summit 2022-1</a></li>
+            <li><a href="summit.html">Summit 2023-1</a></li>
           </ul>
         </p>
       </div>

--- a/summit-2020-1.html
+++ b/summit-2020-1.html
@@ -52,7 +52,8 @@
           <ul>
             <li><a href="summit-2019-2.html">Summit 2019-2</a></li>
             <li><a href="summit-2021-1.html">Summit 2021-1</a></li>
-            <li><a href="summit.html">Summit 2022-1</a></li>
+            <li><a href="summit-2022-1.html">Summit 2022-1</a></li>
+            <li><a href="summit.html">Summit 2023-1</a></li>
           </ul>
         </p>
       </div>

--- a/summit-2021-1.html
+++ b/summit-2021-1.html
@@ -521,7 +521,8 @@
           <ul>
             <li><a href="summit-2019-2.html">Summit 2019-2</a></li>
             <li><a href="summit-2020-1.html">Summit 2020-1</a></li>
-            <li><a href="summit.html">Summit 2022-1</a></li>
+            <li><a href="summit-2022-1.html">Summit 2022-1</a></li>
+            <li><a href="summit.html">Summit 2023-1</a></li>
           </ul>
         </p>
       </div>

--- a/summit-2022-1.html
+++ b/summit-2022-1.html
@@ -1,0 +1,432 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Eiffel Summit</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="./images/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="./images/favicon/favicon-16x16.png">
+    <link rel="manifest" href="./manifest.json">
+    <link rel="mask-icon" href="./images/favicon/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel='stylesheet' href='./css/index.css'>
+    <meta name="theme-color" content="#ffffff">
+    <meta charset="UTF-8">
+    <script src="./js/csi.min.js"></script>
+  </head>
+  <body class="container">
+    <div data-include="./includes/header.html"></div>
+    <section>
+      <div>
+        <p class="splash-text-large">Eiffel Summit 2022.1</p>
+        <p>
+          This in-person two-day conference for people interested in
+          the Eiffel protocol and its ecosystem had a mix of
+          presentations and discussions. Newcomers as well as
+          experienced practitioners were all welcome.
+        </p>
+      </div>
+    </section>
+    <section>
+      <div>
+        <h1 class="section-heading">The practicalities</h1>
+        <p class="section-paragraph">
+          <ul>
+            <li>
+              Where: Nasdaq Stockholm,
+              <a href="https://goo.gl/maps/KpoBwrNw1FPsqcJH8">
+                Tullvaktsvägen&nbsp;15, 105 78 Stockholm, Sweden
+              </a>
+            </li>
+            <li>
+              When: October&nbsp;11, 10:00&nbsp;CEST, to
+              October&nbsp;12, 15:00&nbsp;CEST
+            </li>
+            <li>
+              Who: To get in touch with the organizers send an email to
+              <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>.
+            </li>
+            <li>
+              Communication: For questions, comments, or suggestions regarding the Summit, please join us on <a href="https://eiffel-workspace.slack.com/archives/C02EKUS4M24">Slack</a>.
+            </li>
+          </ul>
+        </p>
+        <h1>Agenda</h1>
+        <h2>Day 1 (Tuesday, October 11)</h2>
+        <table class="striped ">
+          <thead>
+            <tr>
+              <th>Topic</th>
+              <th>Level</th>
+              <th>Start time</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <details>
+                  <summary>Welcome and introductions</summary>
+                  <div>
+                    <p>
+                      There will no doubt be some new faces so let's
+                      introduce ourselves before we start. Our hosts
+                      might also have practical matters to talk about.
+                    </p>
+                    <p>
+                      <b>Speaker:</b> Claes Richárd &amp; Emil Bäckmark
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>10:00</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Community news</summary>
+                  <div>
+                    <ul>
+                      <li>New TC introduction</li>
+                      <li>Decide agenda</li>
+                      <li>New or significantly updated projects</li>
+                    </ul>
+                    <p>
+                      <b>Speaker:</b> Emil Bäckmark &amp; TC members
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>10:20</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Updates on Eiffel visualizations</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>10:50</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Eiffel at Nasdaq</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> Claes Richárd
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_at_nasdaq.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/OjfVzYiQQo4">Video</a>
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>11:10</td>
+            </tr>
+            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Ask me anything</summary>
+                  <div>
+                    <p>
+                      An opportunity for anyone to ask any question about Eiffel
+                      and we'll all help out answering. Possible topics include:
+                    </p>
+                    <ul>
+                      <li>How should we actually use events in a particular scenario?</li>
+                      <li>What Eiffel components exists and how do they interact?</li>
+                      <li>How can Eiffel be deployed in production?</li>
+                    </ul>
+                    <p>
+                      <b>Moderator:</b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:00</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Break</summary>
+                  <div>
+                    <p>
+                      Time to stretch our legs, recaffeinate our vessels and socialize
+                    </p>
+                    <p>
+                      <b>Speaker:</b> All
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+              </td>
+              <td>14:30</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Deployment events</summary>
+                  <div>
+                    <p>
+                      Continue the discussion of how deployments should be
+                      modeled with Eiffel
+                      (see <a href="https://github.com/eiffel-community/eiffel/issues/239">issue&nbsp;239</a>).
+                    </p>
+                    <p>
+                      <b>Moderator:</b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>15:00</td>
+            </tr>
+          </tbody>
+        </table>
+        <h2>Day 2 (Wednesday, October 12)</h2>
+        <table class="striped ">
+          <thead>
+            <tr>
+              <th>Topic</th>
+              <th>Level</th>
+              <th>Start time</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <details>
+                  <summary>CDEvents</summary>
+                  <div>
+                    <p>
+                      What is this new CDEvents thing that people talk about
+                      and how does it relate to Eiffel?
+                    </p>
+                    <p>
+                      <b>Speaker:</b> Emil Bäckmark &amp; Mattias Linnér
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_vs_cdevents.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/EWODpCgxSTs">Video</a>
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>09:00</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Event categorization</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> Mattias Linnér
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>09:50</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Break</summary>
+                  <div>
+                    <p>
+                      Time to stretch our legs, recaffeinate our vessels and socialize
+                    </p>
+                    <p>
+                      <b>Speaker:</b> All
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+              </td>
+              <td>10:20</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Protocol news</summary>
+                  <div>
+                    <ul>
+                      <li>
+                        Checksums for artifact files
+                        (<a href="https://github.com/eiffel-community/eiffel/issues/290">issue&nbsp;290</a>)
+                      </li>
+                      <li>
+                        New file format for schemas and documentation
+                        (<a href="https://github.com/eiffel-community/eiffel/issues/282">issue&nbsp;282</a>)
+                        |
+                        <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/new_format_for_eiffel_schema_definitions.pdf">Slides</a>
+                      </li>
+                      <li>
+                        meta.schemaUri
+                      </li>
+                      <li>
+                        The new PRECURSOR link type
+                        (<a href="https://github.com/eiffel-community/eiffel/issues/227">issue&nbsp;227</a>)
+                      </li>
+                    </ul>
+                    <p>
+                      <b>Speaker:</b> Emil Bäckmark &amp; Magnus Bäck
+                    </p>
+                    <p>
+                      <a href="https://youtu.be/akg9GYAdrXs">Video</a>
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>10:40</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>State of ETOS</summary>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> Tobias Persson &amp; Fredrik Fristedt
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/state_of_etos_2022.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/ZCCsYELOztk">Video</a>
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>11:15</td>
+            </tr>
+            <tr><td>Lunch</td><td></td><td>11:40</td></tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>
+                    Using Eiffel to peek into OpenEmbedded’s hierarchical
+                    source code structure
+                  </summary>
+                  <div>
+                    <p>
+                      It's not entirely obvious how to model a hiearchical
+                      source code structure like that one used with
+                      OpenEmbedded, where the system as a whole is defined
+                      by multiple source code repositories containing
+                      configuration files that, in turn, reference the
+                      source code of the actual code. This talk will show
+                      how Axis Communications does this.
+                    </p>
+                  </div>
+                  <div>
+                    <p>
+                      <b>Speaker:</b> Magnus Bäck
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_with_openembedded_source_structure.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/RgBUGgU6F4M">Video</a>
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td>
+                <span class="tag bd-success" style="border: 1px solid blue !important;">
+                  Intermediate
+                </span>
+              </td>
+              <td>12:30</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Environment events and more</summary>
+                  <div>
+                    <p>
+                      <b>Moderator:</b> Magnus Bäck
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:00</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Coffee and Eiffel 5 years from now</summary>
+                  <div>
+                    <p>
+                      Let's fill our coffee cups and nail down our visions. 
+                      Do we have a vision for where Eiffel should be in 2027?
+                    </p>
+                    <p>
+                      <b>Moderator:</b> Emil Bäckmark
+                    </p>
+                  </div>
+                </details>
+             </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>13:50</td>
+            </tr>
+            <tr>
+              <td>
+                <details>
+                  <summary>Wrap-up</summary>
+                  <div>
+                    <p>
+                      <b>Moderator:</b> Claes Richárd &amp; Emil Bäckmark
+                    </p>
+                  </div>
+                </details>
+              </td>
+              <td><span class="tag bd-success">Beginner</span></td>
+              <td>14:45</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <section>
+      <div>
+        <h1 class="section-heading">Other summits</h1>
+        <p class="section-paragraph">
+          <ul>
+            <li><a href="summit-2019-2.html">Summit 2019-2</a></li>
+            <li><a href="summit-2020-1.html">Summit 2020-1</a></li>
+            <li><a href="summit-2021-1.html">Summit 2021-1</a></li>
+            <li><a href="summit.html">Summit 2023-1</a></li>
+          </ul>
+        </p>
+      </div>
+    </section>
+    <div data-include="includes/footer.html"></div>
+  </body>
+</html>

--- a/summit.html
+++ b/summit.html
@@ -16,12 +16,12 @@
     <div data-include="./includes/header.html"></div>
     <section>
       <div>
-        <p class="splash-text-large">Eiffel Summit 2022.1</p>
+        <p class="splash-text-large">Eiffel Summit 2023.1</p>
         <p>
           This in-person two-day conference for people interested in
-          the Eiffel protocol and its ecosystem had a mix of
+          the Eiffel protocol and its ecosystem will have a mix of
           presentations and discussions. Newcomers as well as
-          experienced practitioners were all welcome.
+          experienced practitioners are welcome.
         </p>
       </div>
     </section>
@@ -31,14 +31,15 @@
         <p class="section-paragraph">
           <ul>
             <li>
-              Where: Nasdaq Stockholm,
-              <a href="https://goo.gl/maps/KpoBwrNw1FPsqcJH8">
-                Tullvaktsvägen&nbsp;15, 105 78 Stockholm, Sweden
+              Where: <a href="https://dowhile.se/">doWhile</a>,
+              <a href="https://goo.gl/maps/ixnYGRBcCbQQw3Gd6">
+                Lindholmspiren&nbsp;7, 417&nbsp;56 Gothenborg, Sweden
               </a>
             </li>
             <li>
-              When: October&nbsp;11, 10:00&nbsp;CEST, to
-              October&nbsp;12, 15:00&nbsp;CEST
+              When: June&nbsp;13, 09:00&nbsp;CEST, 2023, to
+              June&nbsp;14, 17:00&nbsp;CEST
+              (exact start and end times tentative)
             </li>
             <li>
               Who: To get in touch with the organizers send an email to
@@ -50,368 +51,23 @@
           </ul>
         </p>
         <h1>Agenda</h1>
-        <h2>Day 1 (Tuesday, October 11)</h2>
-        <table class="striped ">
-          <thead>
-            <tr>
-              <th>Topic</th>
-              <th>Level</th>
-              <th>Start time</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <details>
-                  <summary>Welcome and introductions</summary>
-                  <div>
-                    <p>
-                      There will no doubt be some new faces so let's
-                      introduce ourselves before we start. Our hosts
-                      might also have practical matters to talk about.
-                    </p>
-                    <p>
-                      <b>Speaker:</b> Claes Richárd &amp; Emil Bäckmark
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>10:00</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Community news</summary>
-                  <div>
-                    <ul>
-                      <li>New TC introduction</li>
-                      <li>Decide agenda</li>
-                      <li>New or significantly updated projects</li>
-                    </ul>
-                    <p>
-                      <b>Speaker:</b> Emil Bäckmark &amp; TC members
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>10:20</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Updates on Eiffel visualizations</summary>
-                  <div>
-                    <p>
-                      <b>Speaker:</b> Magnus Bäck
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>10:50</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Eiffel at Nasdaq</summary>
-                  <div>
-                    <p>
-                      <b>Speaker:</b> Claes Richárd
-                    </p>
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_at_nasdaq.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/OjfVzYiQQo4">Video</a>
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>11:10</td>
-            </tr>
-            <tr><td>Lunch</td><td></td><td>12:00</td></tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Ask me anything</summary>
-                  <div>
-                    <p>
-                      An opportunity for anyone to ask any question about Eiffel
-                      and we'll all help out answering. Possible topics include:
-                    </p>
-                    <ul>
-                      <li>How should we actually use events in a particular scenario?</li>
-                      <li>What Eiffel components exists and how do they interact?</li>
-                      <li>How can Eiffel be deployed in production?</li>
-                    </ul>
-                    <p>
-                      <b>Moderator:</b> Magnus Bäck
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>13:00</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Break</summary>
-                  <div>
-                    <p>
-                      Time to stretch our legs, recaffeinate our vessels and socialize
-                    </p>
-                    <p>
-                      <b>Speaker:</b> All
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-              </td>
-              <td>14:30</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Deployment events</summary>
-                  <div>
-                    <p>
-                      Continue the discussion of how deployments should be
-                      modeled with Eiffel
-                      (see <a href="https://github.com/eiffel-community/eiffel/issues/239">issue&nbsp;239</a>).
-                    </p>
-                    <p>
-                      <b>Moderator:</b> Magnus Bäck
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>15:00</td>
-            </tr>
-          </tbody>
-        </table>
-        <h2>Day 2 (Wednesday, October 12)</h2>
-        <table class="striped ">
-          <thead>
-            <tr>
-              <th>Topic</th>
-              <th>Level</th>
-              <th>Start time</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <details>
-                  <summary>CDEvents</summary>
-                  <div>
-                    <p>
-                      What is this new CDEvents thing that people talk about
-                      and how does it relate to Eiffel?
-                    </p>
-                    <p>
-                      <b>Speaker:</b> Emil Bäckmark &amp; Mattias Linnér
-                    </p>
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_vs_cdevents.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/EWODpCgxSTs">Video</a>
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>09:00</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Event categorization</summary>
-                  <div>
-                    <p>
-                      <b>Speaker:</b> Mattias Linnér
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>09:50</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Break</summary>
-                  <div>
-                    <p>
-                      Time to stretch our legs, recaffeinate our vessels and socialize
-                    </p>
-                    <p>
-                      <b>Speaker:</b> All
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-              </td>
-              <td>10:20</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Protocol news</summary>
-                  <div>
-                    <ul>
-                      <li>
-                        Checksums for artifact files
-                        (<a href="https://github.com/eiffel-community/eiffel/issues/290">issue&nbsp;290</a>)
-                      </li>
-                      <li>
-                        New file format for schemas and documentation
-                        (<a href="https://github.com/eiffel-community/eiffel/issues/282">issue&nbsp;282</a>)
-                        |
-                        <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/new_format_for_eiffel_schema_definitions.pdf">Slides</a>
-                      </li>
-                      <li>
-                        meta.schemaUri
-                      </li>
-                      <li>
-                        The new PRECURSOR link type
-                        (<a href="https://github.com/eiffel-community/eiffel/issues/227">issue&nbsp;227</a>)
-                      </li>
-                    </ul>
-                    <p>
-                      <b>Speaker:</b> Emil Bäckmark &amp; Magnus Bäck
-                    </p>
-                    <p>
-                      <a href="https://youtu.be/akg9GYAdrXs">Video</a>
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>10:40</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>State of ETOS</summary>
-                  <div>
-                    <p>
-                      <b>Speaker:</b> Tobias Persson &amp; Fredrik Fristedt
-                    </p>
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/state_of_etos_2022.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/ZCCsYELOztk">Video</a>
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>11:15</td>
-            </tr>
-            <tr><td>Lunch</td><td></td><td>11:40</td></tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>
-                    Using Eiffel to peek into OpenEmbedded’s hierarchical
-                    source code structure
-                  </summary>
-                  <div>
-                    <p>
-                      It's not entirely obvious how to model a hiearchical
-                      source code structure like that one used with
-                      OpenEmbedded, where the system as a whole is defined
-                      by multiple source code repositories containing
-                      configuration files that, in turn, reference the
-                      source code of the actual code. This talk will show
-                      how Axis Communications does this.
-                    </p>
-                  </div>
-                  <div>
-                    <p>
-                      <b>Speaker:</b> Magnus Bäck
-                    </p>
-                    <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2022.1/eiffel_with_openembedded_source_structure.pdf">Slides</a>
-                      <br>
-                      <a href="https://youtu.be/RgBUGgU6F4M">Video</a>
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td>
-                <span class="tag bd-success" style="border: 1px solid blue !important;">
-                  Intermediate
-                </span>
-              </td>
-              <td>12:30</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Environment events and more</summary>
-                  <div>
-                    <p>
-                      <b>Moderator:</b> Magnus Bäck
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>13:00</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Coffee and Eiffel 5 years from now</summary>
-                  <div>
-                    <p>
-                      Let's fill our coffee cups and nail down our visions. 
-                      Do we have a vision for where Eiffel should be in 2027?
-                    </p>
-                    <p>
-                      <b>Moderator:</b> Emil Bäckmark
-                    </p>
-                  </div>
-                </details>
-             </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>13:50</td>
-            </tr>
-            <tr>
-              <td>
-                <details>
-                  <summary>Wrap-up</summary>
-                  <div>
-                    <p>
-                      <b>Moderator:</b> Claes Richárd &amp; Emil Bäckmark
-                    </p>
-                  </div>
-                </details>
-              </td>
-              <td><span class="tag bd-success">Beginner</span></td>
-              <td>14:45</td>
-            </tr>
-          </tbody>
-        </table>
+        <p>
+          At this early stage very little has been decided
+          regarding the agenda. This page will be updated as we get
+          closer to the date.
+        </p>
+        <p>
+          That said, the second day, June&nbsp;14, is adjacent to the
+          <a href="https://www.software-center.se/event/rws_june2023/">Software
+          Center reporting workshop</a>, and the afternoon of this day
+          aims to cater to a wider audience of people who may not be
+          familar with Eiffel in particular but is well-versed in the
+          CI/CD space in general, possibly from the academic side.
+        </p>
+        <p>
+          If there's any topic you'd like to see covered please reach
+          out to us.
+        </p>
       </div>
     </section>
     <section>
@@ -422,6 +78,7 @@
             <li><a href="summit-2019-2.html">Summit 2019-2</a></li>
             <li><a href="summit-2020-1.html">Summit 2020-1</a></li>
             <li><a href="summit-2021-1.html">Summit 2021-1</a></li>
+            <li><a href="summit-2022-1.html">Summit 2022-1</a></li>
           </ul>
         </p>
       </div>


### PR DESCRIPTION
### Applicable Issues
Fixes #44 

### Description of the Change
Move the old summit information to summit-2022-1.html and update summit.html to contain the limited information available about the 2023.1 summit. Preview at https://magnusbaeck.github.io/eiffel-community.github.io/summit.html.

### Alternate Designs
None.

### Benefits
Early information about the 2023 summit will be made available for use in invites.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
