### PR TITLE
Fix remaining reference to expired Slack invite link

### DIFF
--- a/includes/footer.html
+++ b/includes/footer.html
@@ -2,7 +2,7 @@
         <nav class="nav bg-grey">
           <div class="nav-center">
             <a href="https://groups.google.com/forum/#!forum/eiffel-community">Google Group</a>
-            <a href="https://join.slack.com/t/eiffel-workspace/shared_invite/enQtOTI3MzEzMzY4Mzg0LTA3NDVmNjgzZjk1YTFjNzk5OWE4MjExYzE1ODU1NzA1YzY5MzhlZmYxZmIwMzhiM2ExOWM4ZGJlYzdkN2M5OTE">Slack Workspace</a>
+            <a href="https://join.slack.com/t/eiffel-workspace/shared_invite/zt-1nuw8446s-Dlv5xsItI7QaWj56s4mLdg">Slack Workspace</a>
             <a href="https://www.youtube.com/channel/UC3Zx84ecQ1jyGSc9709xrZg">YouTube Channel</a>
             <a href="https://github.com/eiffel-community/eiffel">Eiffel protocol @ GitHub</a>
             <a href="https://github.com/eiffel-community">Eiffel Community @ GitHub</a>


### PR DESCRIPTION
### Applicable Issues
Fixes #58

### Description of the Change
In #43 we updated the Slack invite link, but only in community.html. The reference in the page footer remained, until now.

See the change in action at https://magnusbaeck.github.io/eiffel-community.github.io/.

### Alternate Designs
None.

### Benefits
Working links.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
