### PR TITLE
Add summit presentation links

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -167,7 +167,8 @@
                     </p>
                     <p>
                       Jonathan Dartland, Nasdaq - Eiffel usage at Nasdaq
-                      <a href="https://youtu.be/kkNlt_7M0Ac">Video</a>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/eiffel-at-nasdaq-2023-1.pdf">Slides</a>
+                      &nbsp;<a href="https://youtu.be/kkNlt_7M0Ac">Video</a>
                     </p>
                     <p>
                       Erik Sternerson, Volvo Cars - Confidence Labels

--- a/summit.html
+++ b/summit.html
@@ -336,7 +336,10 @@
                       <b>Speaker:</b> Kristian Sandahl
                     </p>
                     <p>
-                      <a href="https://youtu.be/PTinecVt20A">Video</a>
+                      <p>
+                        <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Eiffel%20SummitSWC.pdf">Slides</a>
+                        <br>
+                        <a href="https://youtu.be/PTinecVt20A">Video</a>
                     </p>
                   </div>
                 </details>

--- a/summit.html
+++ b/summit.html
@@ -21,7 +21,7 @@
           This in-person two-day conference for people interested in
           the Eiffel protocol and its ecosystem had a mix of
           presentations and discussions. Newcomers as well as
-          experienced practitioners where present.
+          experienced practitioners were present.
         </p>
       </div>
     </section>
@@ -162,7 +162,7 @@
                     <p>
                       Magnus Bäck, Axis Communications - Are multiple contexts a
                       thing?
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Eiffel%20Landscape%20Overview.pdf">Slides</a>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/are_multiple_contexts_a_thing.pdf">Slides</a>
                       &nbsp;<a href="https://youtu.be/bHLsf9x8ik4">Video</a>
                     </p>
                     <p>

--- a/summit.html
+++ b/summit.html
@@ -17,12 +17,11 @@
     <section>
       <div>
         <p class="splash-text-large">Eiffel Summit 2023.1</p>
-        <p class="splash-text-large" style="color: var(--color-error);">SOLD OUT!</p>
         <p>
           This in-person two-day conference for people interested in
-          the Eiffel protocol and its ecosystem will have a mix of
+          the Eiffel protocol and its ecosystem had a mix of
           presentations and discussions. Newcomers as well as
-          experienced practitioners are welcome.
+          experienced practitioners where present.
         </p>
       </div>
     </section>
@@ -53,29 +52,16 @@
             </li>
             <li>
               Communication: For questions, comments, or suggestions regarding the Summit, please join us on <a href="https://eiffel-workspace.slack.com/archives/C02EKUS4M24">Slack</a>.
-              For direct contact during the event, contact Erik at +46 702 007 999.
             </li>
             <li>
               Co-located event: The summit is adjacent to the
               <a href="https://www.software-center.se/event/rws_june2023/">Software
               Center reporting workshop</a> with the intention to cross-pollinate
-              between the two organizations. There might be a joint meetup
-              and/or dinner on Wednesday afternoon, but those plans are not yet
-              set.
+              between the two organizations.
               </li>
-                <li>
-              The registration is now closed, since the summit is sold out.
-              Please send a mail to
-              <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>
-              if you want to be put on the waitlist for the summit.
-            </li>
           </ul>
         </p>
         <h1>Agenda</h1>
-        <p>
-          This is the preliminary agenda. Details might change up until and
-          during the summit.
-        </p>
         <h2>Day 1 (Tuesday, June 13)</h2>
         <table class="striped ">
           <thead>
@@ -138,6 +124,11 @@
                     <p>
                       <b>Speaker:</b> Mattias Linnér
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Eiffel%20Landscape%20Overview.pdf">Slides</a>
+                      <br>
+                      <a href="...">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -160,6 +151,12 @@
                     </p>
                     <p>
                       <b>Speakers:</b> All
+                    </p>
+                    <p>
+                      Magnus Bäck, Axis Communications - Are multiple contexts a
+                      thing?
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Eiffel%20Landscape%20Overview.pdf">Slides</a>
+                      &nbsp;<a href="...">Video</a>
                     </p>
                   </div>
                 </details>
@@ -204,6 +201,11 @@
                     <p>
                       <b>Speakers:</b> Tobias Åkervik &amp; Emil Bäckmark
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/eiffel-collector-services-system.pdf">Slides</a>
+                      <br>
+                      <a href="...">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -236,6 +238,11 @@
                     </p>
                     <p>
                       <b>Moderator:</b> Magnus Bäck
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/new_source_change_events.pdf">Slides</a>
+                      <br>
+                      <a href="...">Video</a>
                     </p>
                   </div>
                 </details>
@@ -332,6 +339,13 @@
                     <p>
                       <b>Speaker:</b> Panagiotis Efstratiou &amp; Emil Bäckmark
                     </p>
+                    <p>
+                      Eiffel @ Nordix: <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Eiffel%20at%20Nordix.pdf">Slides</a>
+                      <br>
+                      Easy2Use on Nordix: <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Easy2Use_on_Nordix.pdf">Slides</a>
+                      <br>
+                      <a href="...">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -358,6 +372,11 @@
                     <p>
                       <b>Speakers:</b> Fatih Degirmenci &amp; Emil Bäckmark
                     </p>
+                    <p>
+                      CDEvents and Eiffel: <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/CDEvents%20and%20Eiffel.pdf">Slides</a>
+                      <br>
+                      <a href="...">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -375,6 +394,11 @@
                     </p>
                     <p>
                       <b>Speaker:</b> Magnus Bäck
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/secure_submissions_of_eiffel_events.pdf">Slides</a>
+                      <br>
+                      <a href="...">Video</a>
                     </p>
                   </div>
                 </details>
@@ -397,6 +421,11 @@
                     <p>
                       <b>Speaker:</b> Magnus Bäck
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/orizaba_the_next_eiffel_edition.pdf">Slides</a>
+                      <br>
+                      <a href="...">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -418,6 +447,11 @@
                     </p>
                     <p>
                       <b>Speaker:</b> Emil Bäckmark
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Eiffel%20Event%20Protocol%20Conformance.pdf">Slides</a>
+                      <br>
+                      <a href="...">Video</a>
                     </p>
                   </div>
                 </details>
@@ -472,6 +506,11 @@
                     </p>
                     <p>
                       <b>Moderator:</b> Mattias Linnér
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Expressing%20a%20confidence%20level%20for%20combination%20of%20SW%20and%20HW.pdf">Slides</a>
+                      <br>
+                      <a href="...">Video</a>
                     </p>
                   </div>
                 </details>

--- a/summit.html
+++ b/summit.html
@@ -103,6 +103,9 @@
                     <p>
                       <b>Speaker:</b> Erik Sternerson
                     </p>
+                    <p>
+                      <a href="https://youtu.be/xVP_00xA9Vo">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -127,7 +130,7 @@
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Eiffel%20Landscape%20Overview.pdf">Slides</a>
                       <br>
-                      <a href="...">Video</a>
+                      <a href="https://youtu.be/k-oP4SlOvZ4">Video</a>
                     </p>
                   </div>
                 </details>
@@ -153,10 +156,22 @@
                       <b>Speakers:</b> All
                     </p>
                     <p>
+                      Kristofer Hallén, Ericsson - Reflections on Ericsson's Eiffel usage
+                      <a href="https://youtu.be/y2uEp9ZX8MM">Video</a>
+                    </p>
+                    <p>
                       Magnus Bäck, Axis Communications - Are multiple contexts a
                       thing?
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Eiffel%20Landscape%20Overview.pdf">Slides</a>
-                      &nbsp;<a href="...">Video</a>
+                      &nbsp;<a href="https://youtu.be/bHLsf9x8ik4">Video</a>
+                    </p>
+                    <p>
+                      Jonathan Dartland, Nasdaq - Eiffel usage at Nasdaq
+                      <a href="https://youtu.be/kkNlt_7M0Ac">Video</a>
+                    </p>
+                    <p>
+                      Erik Sternerson, Volvo Cars - Confidence Labels
+                      <a href="https://youtu.be/Z5Wk_7AZ8FE">Video</a>
                     </p>
                   </div>
                 </details>
@@ -199,12 +214,12 @@
                       Intelligence
                     </p>
                     <p>
-                      <b>Speakers:</b> Tobias Åkervik &amp; Emil Bäckmark
+                      <b>Speakers:</b> Tobias Åkervik
                     </p>
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/eiffel-collector-services-system.pdf">Slides</a>
                       <br>
-                      <a href="...">Video</a>
+                      <a href="https://youtu.be/M5IWEaHtNy0">Video</a>
                     </p>
                   </div>
                 </details>
@@ -242,7 +257,7 @@
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/new_source_change_events.pdf">Slides</a>
                       <br>
-                      <a href="...">Video</a>
+                      <a href="https://youtu.be/i8cFThy5-zc">Video</a>
                     </p>
                   </div>
                 </details>
@@ -320,6 +335,9 @@
                     <p>
                       <b>Speaker:</b> Kristian Sandahl
                     </p>
+                    <p>
+                      <a href="https://youtu.be/PTinecVt20A">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -344,7 +362,7 @@
                       <br>
                       Easy2Use on Nordix: <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Easy2Use_on_Nordix.pdf">Slides</a>
                       <br>
-                      <a href="...">Video</a>
+                      <a href="https://youtu.be/jTN-TIP7bpA">Video</a>
                     </p>
                   </div>
                 </details>
@@ -375,7 +393,7 @@
                     <p>
                       CDEvents and Eiffel: <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/CDEvents%20and%20Eiffel.pdf">Slides</a>
                       <br>
-                      <a href="...">Video</a>
+                      <a href="https://youtu.be/Sn-i5rtjr3w">Video</a>
                     </p>
                   </div>
                 </details>
@@ -398,7 +416,7 @@
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/secure_submissions_of_eiffel_events.pdf">Slides</a>
                       <br>
-                      <a href="...">Video</a>
+                      <a href="https://youtu.be/qnluL_Q-q2Y">Video</a>
                     </p>
                   </div>
                 </details>
@@ -424,7 +442,7 @@
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/orizaba_the_next_eiffel_edition.pdf">Slides</a>
                       <br>
-                      <a href="...">Video</a>
+                      <a href="https://youtu.be/zzvNKwvRkh8">Video</a>
                     </p>
                   </div>
                 </details>
@@ -451,7 +469,7 @@
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Eiffel%20Event%20Protocol%20Conformance.pdf">Slides</a>
                       <br>
-                      <a href="...">Video</a>
+                      <a href="https://youtu.be/LowARykMySA">Video</a>
                     </p>
                   </div>
                 </details>
@@ -475,6 +493,9 @@
                     </p>
                     <p>
                       <b>Speaker:</b> Erik Sternerson
+                    </p>
+                    <p>
+                      <a href="https://youtu.be/NgvVCv3wUG8">Video</a>
                     </p>
                   </div>
                 </details>
@@ -510,7 +531,7 @@
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/Expressing%20a%20confidence%20level%20for%20combination%20of%20SW%20and%20HW.pdf">Slides</a>
                       <br>
-                      <a href="...">Video</a>
+                      <a href="https://youtu.be/5lQHr54-wI8">Video</a>
                     </p>
                   </div>
                 </details>

--- a/summit.html
+++ b/summit.html
@@ -156,22 +156,22 @@
                       <b>Speakers:</b> All
                     </p>
                     <p>
-                      Kristofer Hallén, Ericsson - Reflections on Ericsson's Eiffel usage
+                      Kristofer Hallén, Ericsson &ndash; Reflections on Ericsson's Eiffel usage
                       <a href="https://youtu.be/y2uEp9ZX8MM">Video</a>
                     </p>
                     <p>
-                      Magnus Bäck, Axis Communications - Are multiple contexts a
+                      Magnus Bäck, Axis Communications &ndash; Are multiple contexts a
                       thing?
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/are_multiple_contexts_a_thing.pdf">Slides</a>
                       &nbsp;<a href="https://youtu.be/bHLsf9x8ik4">Video</a>
                     </p>
                     <p>
-                      Jonathan Dartland, Nasdaq - Eiffel usage at Nasdaq
+                      Jonathan Dartland, Nasdaq &ndash; Eiffel usage at Nasdaq
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/eiffel-at-nasdaq-2023-1.pdf">Slides</a>
                       &nbsp;<a href="https://youtu.be/kkNlt_7M0Ac">Video</a>
                     </p>
                     <p>
-                      Erik Sternerson, Volvo Cars - Confidence Labels
+                      Erik Sternerson, Volvo Cars &ndash; Confidence Labels
                       <a href="https://youtu.be/Z5Wk_7AZ8FE">Video</a>
                     </p>
                   </div>
@@ -199,7 +199,7 @@
                   </div>
                 </details>
               </td>
-              <td><span class="tag bd-success">Beginner - Advanced</span></td>
+              <td><span class="tag bd-success">Beginner &ndash; Advanced</span></td>
               <td>13:00</td>
             </tr>
 


### PR DESCRIPTION
### Applicable Issues
None

### Description of the Change
Adds links in the summit homepage to pdf presentations and Youtube videos from recordings on the Eiffel Summit 2023.1

Preview: https://e-backmark-ericsson.github.io/eiffel-community.github.io/summit.html

### Alternate Designs
.

### Benefits
To easily find presentations and recordings

### Possible Drawbacks
-

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emil Bäckmark emil.backmark@ericsson.com