### PR TITLE
summit.html: Add link to CD Foundation slide pack

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -395,6 +395,8 @@
                       <b>Speakers:</b> Fatih Degirmenci &amp; Emil Bäckmark
                     </p>
                     <p>
+                      CD Foundation: <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/CDF_Overview.pdf">Slides</a>
+                      <br>
                       CDEvents and Eiffel: <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2023.1/CDEvents%20and%20Eiffel.pdf">Slides</a>
                       <br>
                       <a href="https://youtu.be/Sn-i5rtjr3w">Video</a>


### PR DESCRIPTION
### Applicable Issues
None.

### Description of the Change
Add a link to the CDF Overview slide PDF, added to the community repo in https://github.com/eiffel-community/community/pull/174.

### Alternate Designs
None.

### Benefits
More slide packs from the summit available.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
