### PR TITLE
Summit: Add note about closed registration

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -44,12 +44,9 @@
               <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>.
             </li>
             <li>
-              Registration: Please sign up using the
-              <a href="https://forms.gle/jepf1nzXxdQHnmim9">
-                registration form
-              </a> no later than August&nbsp;22. There's limited space
-              available and we may have to close the form before that
-              date.
+              Registration: <b>The registration is now closed.</b> Please contact 
+              <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>
+              if you want to request a late registration and we'll see if we can accommodate it.
             </li>
             <li>
               Communication: For questions, comments, or suggestions regarding the Summit, please join us on <a href="https://eiffel-workspace.slack.com/archives/C02EKUS4M24">Slack</a>.


### PR DESCRIPTION
### Applicable Issues
-

### Description of the Change
Add note about registration being closed
Preview available: https://e-backmark-ericsson.github.io/eiffel-community.github.io/summit.html

### Alternate Designs
-

### Possible Drawbacks
-

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emil Bäckmark, emil.backmark@ericsson.com