### PR TITLE
summit.html: Change to past tense and add links to slides & videos

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -18,10 +18,10 @@
       <div>
         <p class="splash-text-large">Eiffel Summit 2024.1</p>
         <p>
-          This in-person two-day conference is intended for people interested in
-          the Eiffel protocol and its ecosystem hosting a mix of
+          This in-person two-day conference was intended for people interested in
+          the Eiffel protocol and its ecosystem, hosting a mix of
           presentations and discussions. Newcomers as well as
-          experienced practitioners are welcome.
+          experienced practitioners were present.
         </p>
       </div>
     </section>
@@ -44,22 +44,12 @@
               <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>.
             </li>
             <li>
-              Registration: <b>The registration is now closed.</b> Please contact 
-              <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>
-              if you want to request a late registration and we'll see if we can accommodate it.
-            </li>
-            <li>
               Communication: For questions, comments, or suggestions regarding the Summit, please join us on <a href="https://eiffel-workspace.slack.com/archives/C02EKUS4M24">Slack</a>.
             </li>
 
           </ul>
         </p>
         <h1>Agenda</h1>
-        <p>
-          The following agenda is preliminary and is subject to change
-          up until the start of the event, but we'll try to not make
-          too big changes.
-        </p>
         <h2>Day 1 (Wednesday, September 4)</h2>
         <table class="striped ">
           <thead>
@@ -82,6 +72,9 @@
                     <p>
                       <b>Speakers:</b> Edvin Agnas (Volvo Group)
                     </p>
+                    <p>
+                      <a href="https://youtu.be/ijHqbYxnKLI">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -102,7 +95,13 @@
                     <p>
                       <b>Speakers:</b>
                       Magnus Bäck (Axis Communications),
-                      Emil Bäckmark (Ericsson)
+                      Emil Bäckmark (Ericsson), and
+                      Mattias Linnér (Ericsson)
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2024.1/Eiffel_for_beginners.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/ijHqbYxnKLI?t=273">Video</a>
                     </p>
                   </div>
                 </details>
@@ -120,6 +119,11 @@
                   <div>
                     <p>
                       We continue the previous session after the break.
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2024.1/Eiffel_for_beginners.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/lXoOjt7ZDuE">Video</a>
                     </p>
                   </div>
                 </details>
@@ -168,6 +172,9 @@
                       <b>Speakers:</b> Edvin Agnas, Bojan Alempijevic,
                       and Anders Holmblad (Volvo Group)
                     </p>
+                    <p>
+                      <a href="https://youtu.be/hvUy1dPLY3s">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -187,6 +194,11 @@
                     </p>
                     <p>
                       <b>Speakers:</b> Magnus Bäck (Axis Communications)
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2024.1/Signing_Eiffel_events.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/LAwpcrGdy8o">Video</a>
                     </p>
                   </div>
                 </details>
@@ -209,6 +221,9 @@
                     </p>
                     <p>
                       <b>Moderator:</b> Edvin Agnas (Volvo Group)
+                    </p>
+                    <p>
+                      <a href="https://youtu.be/ee7Wah4_QAI">Video</a>
                     </p>
                   </div>
                 </details>
@@ -318,6 +333,11 @@
                     <p>
                       <b>Moderator:</b> Shri Raksha (Volvo Group)
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2024.1/Alternative_approaches_to_modeling_git_submodules.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/rgw8QcHQFho">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -364,6 +384,11 @@
                       Magnus Bäck (Axis Communcations) and
                       Mattias Linnér (Ericsson)
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2024.1/Filtering_and_scaling_of_Eiffel.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/IR2gVCLMMfc">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -386,6 +411,11 @@
                     <p>
                       <b>Speaker:</b> Emil Bäckmark (Ericsson)
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2024.1/Contributing_to_the_Eiffel_open_source_community.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/wVQ3dxUJiSU">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -405,6 +435,11 @@
                     </p>
                     <p>
                       <b>Speaker:</b> Magnus Bäck (Axis Communications)
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2024.1/Santiago-the_next_Eiffel_edition.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/-c47Ex5IhdM">Video</a>
                     </p>
                   </div>
                 </details>
@@ -427,6 +462,9 @@
                     </p>
                     <p>
                       <b>Moderator:</b> Edvin Agnas (Volvo Group)
+                    </p>
+                    <p>
+                      <a href="https://youtu.be/-c47Ex5IhdM?t=1110">Video</a>
                     </p>
                   </div>
                 </details>


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
The summit is over and we should change future tense to past tense and add links to slides and videos from the sessions. Skipping a video or two until we've cleared everyone's permission. See the result at https://magnusbaeck.github.io/eiffel-community.github.io/summit.html.

### Alternate Designs
N/A

### Possible Drawbacks
N/A

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
