### PR TITLE
summit.html: Add full agenda

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -179,6 +179,13 @@
                   <summary>Eiffel Future: Eiffel vs OTel</summary>
                   <div>
                     <p>
+                      OTel (Open Telemetry) has risen as the de facto
+                      standard in observability. Recently it has
+                      expanded into CI/CD space. Let us dive into the
+                      subject and explore how this might affect
+                      Eiffel.
+                    </p>
+                    <p>
                       <b>Speaker:</b> Mattias Linnér (Ericsson)
                     </p>
                   </div>
@@ -355,6 +362,12 @@
                   <summary>How does Eiffel relate to CDEvents?</summary>
                   <div>
                     <p>
+                      CDEvents is a very similar protocol to
+                      Eiffel. The session will shortly introduce
+                      CDEvents giving the participant an overview of
+                      the key differences and where it stands today.
+                    </p>
+                    <p>
                       <b>Speakers:</b> Mattias Linnér (Ericsson)
                     </p>
                   </div>
@@ -369,6 +382,14 @@
                 <details>
                   <summary>Community future</summary>
                   <div>
+                    <p>
+                      When we are in one room, let us discuss the
+                      future of the Eiffel Community. The discussion
+                      will revolve around four areas: The projects in
+                      the community, Eiffel Technical Committee, the
+                      monthly Community Meetups and the next Eiffel
+                      Summit.
+                    </p>
                     <p>
                       <b>Speakers:</b> Mattias Linnér (Ericsson)
                     </p>


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
Replace the placeholder agenda with a full agenda in the traditional look. Many agenda items lack a full description, but apart from getting them in place no major changes are expected at this point. See it live at https://magnusbaeck.github.io/eiffel-community.github.io/summit.html.

### Alternate Designs
None.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
