### PR TITLE
summit.html: Close registration

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -45,9 +45,12 @@
               Communication: For questions, comments, or suggestions regarding the Summit, please join us on <a href="https://eiffel-workspace.slack.com/archives/C02EKUS4M24">Slack</a>.
             </li>
             <li>
-              Registration: Via our <a href="https://forms.gle/pT6odJ79ZMmWS6pY7">Registration Form</a>
+              Registration: <b>The registration is now closed.</b>
+              Please contact
+              <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>
+              if you want to request a late registration and we'll see
+              if we can accommodate it.
             </li>
-
           </ul>
         </p>
 


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
We have now passed the date when we'd agreed with the organizers that we should close the registration to give them sufficient time to plan the venue, so removing the link to the sign-up form.

### Alternate Designs
None.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
