### PR TITLE
summit.html: Update to past tense and link to Magnus's slides

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -18,10 +18,10 @@
       <div>
         <p class="splash-text-large">Eiffel Summit 2025.1</p>
         <p>
-          This in-person two-day conference is intended for people interested in
+          This in-person two-day conference was intended for people interested in
           the Eiffel protocol and its ecosystem, hosting a mix of
           presentations and discussions. Newcomers as well as
-          experienced practitioners are welcome.
+          experienced practitioners were present.
         </p>
       </div>
     </section>
@@ -43,13 +43,6 @@
             </li>
             <li>
               Communication: For questions, comments, or suggestions regarding the Summit, please join us on <a href="https://eiffel-workspace.slack.com/archives/C02EKUS4M24">Slack</a>.
-            </li>
-            <li>
-              Registration: <b>The registration is now closed.</b>
-              Please contact
-              <a href="mailto:eiffel-tc@googlegroups.com">eiffel-tc@googlegroups.com</a>
-              if you want to request a late registration and we'll see
-              if we can accommodate it.
             </li>
           </ul>
         </p>
@@ -94,6 +87,9 @@
                 <details>
                   <summary>Presentation of Tietoevry</summary>
                   <div>
+                    <p>
+                      <b>Speakers:</b> Caroline Castenbladh (Tietoevry)
+                    </p>
                   </div>
                 </details>
               </td>
@@ -112,7 +108,10 @@
                       proposed changes that haven't been merged yet.
                     </p>
                     <p>
-                      <b>Speakers:</b> Magnus Bäck (Axis Communications)
+                      <b>Speakers:</b> Magnus Bäck (Axis Communications) and Mattias Linnér (Ericsson)
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Protocol_news.pdf">Slides</a>
                     </p>
                   </div>
                 </details>
@@ -134,7 +133,10 @@
                       proposed changes that haven't been merged yet.
                     </p>
                     <p>
-                      <b>Speaker:</b> Magnus Bäck (Axis Communications)
+                      <b>Speakers:</b> Magnus Bäck (Axis Communications) and Mattias Linnér (Ericsson)
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Protocol_news.pdf">Slides</a>
                     </p>
                   </div>
                 </details>
@@ -317,6 +319,9 @@
                     <p>
                       <b>Speaker:</b> Magnus Bäck (Axis Communications)
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Using_a_certificate_authority_to_manage_signing_keys.pdf">Slides</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -395,6 +400,9 @@
                     <p>
                       <b>Speakers:</b> Magnus Bäck (Axis Communications)
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/A_standardized_event_submission_API.pdf">Slides</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -418,6 +426,9 @@
                     </p>
                     <p>
                       <b>Speakers:</b> Magnus Bäck (Axis Communications)
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Purging_old_and_outdated_events.pdf">Slides</a>
                     </p>
                   </div>
                 </details>
@@ -464,7 +475,6 @@
 
           </tbody>
         </table>
-
 
       </div>
     </section>


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
The summit is over so we should change the wording to past tense and remove anything that indicates that the summit lies in the future. Also adding links to the first batch of presentation slides, added in https://github.com/eiffel-community/community/pull/221. Live at https://magnusbaeck.github.io/eiffel-community.github.io/summit.html.

### Alternate Designs
Could've split the tense change and slide link additions in two commits.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
