### PR TITLE
summit.html: Add YouTube links and a few more slides

### DIFF
--- a/summit.html
+++ b/summit.html
@@ -111,7 +111,11 @@
                       <b>Speakers:</b> Magnus Bäck (Axis Communications) and Mattias Linnér (Ericsson)
                     </p>
                     <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Protocol_news.pdf">Slides</a>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Protocol_news.pdf">Slides (1)</a>
+                      <br>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Modeling%20Source%20Change%20Verdicts.pdf">Slides (2)</a>
+                      <br>
+                      <a href="https://youtu.be/BS-ilmJxVlg">Video</a>
                     </p>
                   </div>
                 </details>
@@ -136,7 +140,11 @@
                       <b>Speakers:</b> Magnus Bäck (Axis Communications) and Mattias Linnér (Ericsson)
                     </p>
                     <p>
-                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Protocol_news.pdf">Slides</a>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Protocol_news.pdf">Slides (1)</a>
+                      <br>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Modeling%20Source%20Change%20Verdicts.pdf">Slides (2)</a>
+                      <br>
+                      <a href="https://youtu.be/BS-ilmJxVlg">Video</a>
                     </p>
                   </div>
                 </details>
@@ -155,6 +163,9 @@
                     </p>
                     <p>
                       <b>Speaker:</b>Liubov Guseva (Tietoevry)
+                    </p>
+                    <p>
+                      <a href="https://youtu.be/tm29W0OWj5U">Video</a>
                     </p>
                   </div>
                 </details>
@@ -181,6 +192,11 @@
                     <p>
                       <b>Speakers:</b> Mattias Linnér (Ericsson)
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Community%20future.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/TiorGBLasYk">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -203,6 +219,11 @@
                     <p>
                       <b>Speaker:</b> Mattias Linnér (Ericsson)
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Eiffel%20vs%20OTel.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/ElsPetQc6Os">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -217,6 +238,9 @@
                   <div>
                     <p>
                       <b>Speakers:</b> Bojan Alempijevic (Volvo Trucks)
+                    </p>
+                    <p>
+                      <a href="https://youtu.be/NckSzswWJ3o">Video</a>
                     </p>
                   </div>
                 </details>
@@ -321,6 +345,8 @@
                     </p>
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Using_a_certificate_authority_to_manage_signing_keys.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/llHhfs-hrx4">Video</a>
                     </p>
                   </div>
                 </details>
@@ -362,6 +388,11 @@
                     <p>
                       <b>Speaker:</b> Helena Slívová (Tietoevry)
                     </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/SBOM%20with%20Eiffel.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/AEx_KgjAaFY">Video</a>
+                    </p>
                   </div>
                 </details>
               </td>
@@ -379,6 +410,11 @@
                     </p>
                     <p>
                       <b>Speakers:</b> Mattias Linnér (Ericsson)
+                    </p>
+                    <p>
+                      <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/How%20does%20Eiffel%20relate%20to%20CDEvents.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/fXefGdDCal0">Video</a>
                     </p>
                   </div>
                 </details>
@@ -402,6 +438,8 @@
                     </p>
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/A_standardized_event_submission_API.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/JsevIYLj7s4">Video</a>
                     </p>
                   </div>
                 </details>
@@ -429,6 +467,8 @@
                     </p>
                     <p>
                       <a href="https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2025.1/Purging_old_and_outdated_events.pdf">Slides</a>
+                      <br>
+                      <a href="https://youtu.be/k5D3xsDhDZw">Video</a>
                     </p>
                   </div>
                 </details>


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
All available YouTube videos are now linked from the summit page. Also adding links to the slides added to the community git in https://github.com/eiffel-community/community/pull/222. Live at https://magnusbaeck.github.io/eiffel-community.github.io/summit.html.

### Alternate Designs
None.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
